### PR TITLE
Merge from develop - Shortcodes and Third Party theme conflict resolution

### DIFF
--- a/src/class-beans-simple-edits-admin.php
+++ b/src/class-beans-simple-edits-admin.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace LearningCurve\BeansSimpleEdits;
 
 class Beans_Simple_Edits_Admin {
@@ -18,6 +19,9 @@ class Beans_Simple_Edits_Admin {
 	 */
 	public $simple_edits;
 
+	/**
+	 * The array of Beans Simple Shortcodes that can be used.
+	 */
 	public $simple_shortcodes;
 
 
@@ -32,7 +36,7 @@ class Beans_Simple_Edits_Admin {
 		$this->plugin_textdomain = Beans_Simple_Edits()->plugin_textdomain;
 		$this->simple_edits      = Beans_Simple_Edits()->simple_edits;
 
-		if( class_exists( 'LearningCurve\BeansSimpleShortcodes\Beans_Simple_Shortcodes' ) ) {
+		if ( class_exists( 'LearningCurve\BeansSimpleShortcodes\Beans_Simple_Shortcodes' ) ) {
 			$this->simple_shortcodes = \LearningCurve\BeansSimpleShortcodes\Beans_Simple_Shortcodes()->enabled_shortcodes;
 			array_unshift( $this->simple_edits, 'simple_shortcodes' );
 		}
@@ -70,7 +74,7 @@ class Beans_Simple_Edits_Admin {
 	}
 
 	/**
-	 * Add each of the simple edits.
+	 * Hook methods to register each of the simple edits metaboxes.
 	 *
 	 * @param $simple_edit string single item from the $simple_edits array.
 	 */
@@ -81,7 +85,7 @@ class Beans_Simple_Edits_Admin {
 	}
 
 	/**
-	 * Beans options page content.
+	 * Beans Simple Edits options page view.
 	 */
 	public function display_simple_edits_settings_screen() {
 
@@ -89,24 +93,28 @@ class Beans_Simple_Edits_Admin {
 
 	}
 
+
+	/**
+	 * Register the available Beans Simple Shortcodes metabox.
+	 */
 	public function register_simple_shortcodes_edits() {
 
 		$shortcodes = $this->simple_shortcodes;
 
 		$available_shortcodes = [];
 
-		foreach ($shortcodes as $shortcode) {
+		foreach ( $shortcodes as $shortcode ) {
 			$available_shortcodes[] = '<span style="display: inline-block; margin: 10px 15px;"> [beans_' . $shortcode . ']</span>';
 		}
 
-		$available_shortcodes = implode(" ", $available_shortcodes);
+		$available_shortcodes = implode( " ", $available_shortcodes );
 
-		$shortcodes_settings= esc_url( get_site_url() . '/wp-admin/themes.php?page=beans_simple_shortcodes_settings' );
+		$shortcodes_settings = esc_url( get_site_url() . '/wp-admin/themes.php?page=beans_simple_shortcodes_settings' );
 
 		$fields = array(
 			array(
 				'id'          => 'beans_available_simple_shortcodes',
-				'label'     => __( 'For a full description of each shortcodes functionality and attributes, and to enable or disable different shortcodes, please refer to the <a href="' . $shortcodes_settings . '">Beans Simple Shortcodes settings page</a>', $this->plugin_textdomain ),
+				'label'       => __( 'For a full description of each shortcodes functionality and attributes, and to enable or disable different shortcodes, please refer to the <a href="' . $shortcodes_settings . '">Beans Simple Shortcodes settings page</a>', $this->plugin_textdomain ),
 				'description' => __( "<p style='text-align: left;'>{$available_shortcodes}</p>", $this->plugin_textdomain ),
 				'type'        => '',
 				'default'     => ''
@@ -120,7 +128,7 @@ class Beans_Simple_Edits_Admin {
 	}
 
 	/**
-	 * Register options.
+	 * Register the Beans Simple Edits Entry Meta metabox.
 	 */
 	public function register_post_meta_edits() {
 
@@ -162,14 +170,14 @@ class Beans_Simple_Edits_Admin {
 		);
 
 		beans_register_options( $fields, 'beans_simple_edits_settings', 'beans_post_meta_edits', array(
-			'title'   => __( 'Beans Entry Meta Edits', $this->plugin_textdomain ),
+			'title'   => __( 'Beans Simple Edits Entry Meta', $this->plugin_textdomain ),
 			'context' => 'normal',
 		) );
 
 	}
 
 	/**
-	 * Register options.
+	 * Register the Beans Simple Edits Split Footer metabox
 	 */
 	public function register_split_footer_edits() {
 
@@ -211,14 +219,14 @@ class Beans_Simple_Edits_Admin {
 		);
 
 		beans_register_options( $fields, 'beans_simple_edits_settings', 'beans_split_footer_text_credits_edits', array(
-			'title'   => __( 'Beans Standard (Split) Footer Credit Text Edits', $this->plugin_textdomain ),
+			'title'   => __( 'Beans Simple Edits Split Footer', $this->plugin_textdomain ),
 			'context' => 'normal',
 		) );
 
 	}
 
 	/**
-	 * Register options.
+	 * Register the Beans Simple Edits Center Footer metabox.
 	 */
 	public function register_center_footer_edits() {
 
@@ -243,7 +251,7 @@ class Beans_Simple_Edits_Admin {
 		);
 
 		beans_register_options( $fields, 'beans_simple_edits_settings', 'beans_center_footer_edits', array(
-			'title'   => __( 'Create a Centered Beans Footer', $this->plugin_textdomain ),
+			'title'   => __( 'Beans Simple Edits Center Footer', $this->plugin_textdomain ),
 			'context' => 'normal',
 		) );
 

--- a/src/class-beans-simple-edits-admin.php
+++ b/src/class-beans-simple-edits-admin.php
@@ -18,6 +18,9 @@ class Beans_Simple_Edits_Admin {
 	 */
 	public $simple_edits;
 
+	public $simple_shortcodes;
+
+
 	/**
 	 * Constructor.
 	 *
@@ -28,6 +31,12 @@ class Beans_Simple_Edits_Admin {
 		$this->plugin_version    = Beans_Simple_Edits()->plugin_version;
 		$this->plugin_textdomain = Beans_Simple_Edits()->plugin_textdomain;
 		$this->simple_edits      = Beans_Simple_Edits()->simple_edits;
+
+		if( class_exists( 'LearningCurve\BeansSimpleShortcodes\Beans_Simple_Shortcodes' ) ) {
+			$this->simple_shortcodes = \LearningCurve\BeansSimpleShortcodes\Beans_Simple_Shortcodes()->enabled_shortcodes;
+			array_unshift( $this->simple_edits, 'simple_shortcodes' );
+		}
+
 	}
 
 	/**
@@ -78,6 +87,36 @@ class Beans_Simple_Edits_Admin {
 
 		require __DIR__ . "/views/admin.php";
 
+	}
+
+	public function register_simple_shortcodes_edits() {
+
+		$shortcodes = $this->simple_shortcodes;
+
+		$available_shortcodes = [];
+
+		foreach ($shortcodes as $shortcode) {
+			$available_shortcodes[] = '<span style="display: inline-block; margin: 10px 15px;"> [beans_' . $shortcode . ']</span>';
+		}
+
+		$available_shortcodes = implode(" ", $available_shortcodes);
+
+		$shortcodes_settings= esc_url( get_site_url() . '/wp-admin/themes.php?page=beans_simple_shortcodes_settings' );
+
+		$fields = array(
+			array(
+				'id'          => 'beans_available_simple_shortcodes',
+				'label'     => __( 'For a full description of each shortcodes functionality and attributes, and to enable or disable different shortcodes, please refer to the <a href="' . $shortcodes_settings . '">Beans Simple Shortcodes settings page</a>', $this->plugin_textdomain ),
+				'description' => __( "<p style='text-align: left;'>{$available_shortcodes}</p>", $this->plugin_textdomain ),
+				'type'        => '',
+				'default'     => ''
+			),
+		);
+
+		beans_register_options( $fields, 'beans_simple_edits_settings', 'available_beans_simple_shortcodes', array(
+			'title'   => __( 'Available Beans Simple Shortcodes', $this->plugin_textdomain ),
+			'context' => 'normal',
+		) );
 	}
 
 	/**

--- a/src/class-beans-simple-edits-core.php
+++ b/src/class-beans-simple-edits-core.php
@@ -10,52 +10,52 @@ class Beans_Simple_Edits_Core {
 	public $plugin_textdomain;
 
 	/**
-	 * Post meta above content option.
+	 * Content from the Beans Simple Edits Entry Meta (Above Content) textarea.
 	 */
 	private $post_meta_above_content;
 
 	/**
-	 * Remove post meta above content option.
+	 * Checkbox state to remove the Entry Meta (Above Content) span completely. - If enabled then remove.
 	 */
 	private $remove_post_meta_above_content;
 
 	/**
-	 * Post meta below content option.
+	 * Content from the Beans Simple Edits Entry Meta (Below Content) textarea.
 	 */
 	private $post_meta_below_content;
 
 	/**
-	 * Remove post meta below content option.
+	 * Checkbox state to remove the Entry Meta (Above Content) span completely - if enabled then remove.
 	 */
 	private $remove_post_meta_below_content;
 
 	/**
-	 * Split footer left content option.
+	 * Content from the Beans Simple Edits Split Footer (Left) textarea.
 	 */
 	private $split_footer_left;
 
 	/**
-	 * Remove split footer left content option.
+	 * Checkbox state to remove the Split Footer (Left) span completely - if enabled then remove.
 	 */
 	private $remove_split_footer_left;
 
 	/**
-	 * Split footer right content option.
+	 * Content from the Beans Simple Edits Split Footer (Right) textarea.
 	 */
 	private $split_footer_right;
 
 	/**
-	 * Remove split footer right content option.
+	 * Checkbox state to remove the Split Footer (Right) span completely - if enabled then remove.
 	 */
 	private $remove_split_footer_right;
 
 	/**
-	 * Display center footer option.
+	 * Content from the Beans Simple Edits Center Footer textarea.
 	 */
 	private $center_footer;
 
 	/**
-	 * Display center footer show option.
+	 * Checkbox state to display the Center Footer and disable any Split Footer - if enabled then display.
 	 */
 	private $show_center_footer;
 
@@ -79,7 +79,7 @@ class Beans_Simple_Edits_Core {
 	}
 
 	/**
-	 *
+	 * Initialize
 	 */
 	public function init() {
 
@@ -106,25 +106,20 @@ class Beans_Simple_Edits_Core {
 		}
 
 
-
 		if ( $this->show_center_footer ) {
 
-			beans_remove_action( 'beans_footer_content' );
+			beans_add_smart_action( 'after_setup_theme', array( $this, 'beans_simple_edits_replace_central_footer') );
 
-			beans_add_smart_action( 'beans_footer', array( $this, 'beans_simple_edits_footer_content' ) );
+		} elseif ( $this->split_footer_left || $this->split_footer_right ) {
 
-		} else {
-
-			beans_add_filter( 'beans_footer_credit_text_output', array( $this, 'modify_footer_credit_text_left' ), 9999 );
-
-			beans_add_filter( 'beans_footer_credit_right_text_output', array( $this, 'modify_footer_credit_text_right' ), 9999 );
+			beans_add_smart_action( 'after_setup_theme', array( $this, 'beans_simple_edits_replace_split_footers') );
 
 		}
 
 	}
 
 	/**
-	 *
+	 * Replace the standard above content post meta with the Beans Simple Edits above content post meta.
 	 */
 	function beans_simple_edits_post_meta() {
 
@@ -144,7 +139,7 @@ class Beans_Simple_Edits_Core {
 	}
 
 	/**
-	 *
+	 * Replace the standard below content post meta with the Beans Simple Edits below content post meta.
 	 */
 	function beans_simple_edits_post_meta_categories() {
 
@@ -160,62 +155,35 @@ class Beans_Simple_Edits_Core {
 	}
 
 	/**
-	 * @param $output
-	 *
-	 * @return string
+	 * Replace the footer content with the simple edits split footer if it is active.
+	 * Hooked to 'after_theme_setup' to ensure third party child theme footer customisations are overwritten.
 	 */
-	function modify_footer_credit_text_left( $output ) {
+	function beans_simple_edits_replace_split_footers() {
 
-		if ( $this->remove_split_footer_left ) {
+		beans_remove_action( 'beans_footer_content' );
 
-			return '';
-
-		}
-
-		if ( ! $this->split_footer_left ) {
-
-			return $output;
-
-		}
-
-		return do_shortcode( __( $this->split_footer_left, $this->plugin_textdomain ) );
+		beans_add_smart_action( 'beans_footer', array( $this, 'beans_simple_edits_split_footer' ) );
 
 	}
 
 	/**
-	 * @param $output
-	 *
-	 * @return string
+	 * Replace the footer content with the simple edits central footer if it is active.
+	 * Hooked to 'after_theme_setup' to ensure third party child theme footer customisations are overwritten.
 	 */
-	function modify_footer_credit_text_right( $output ) {
+	function beans_simple_edits_replace_central_footer() {
 
-		if ( $this->remove_split_footer_right ) {
+		beans_remove_action( 'beans_footer_content' );
 
-			return '';
-
-		}
-
-		if ( ! $this->split_footer_right ) {
-
-			return $output;
-
-		}
-
-		return do_shortcode( __( $this->split_footer_right, $this->plugin_textdomain ) );
-
-//		return beans_output_e(
-//			'beans_footer_center_credit_text',
-//			do_shortcode( __( $this->split_footer_right, $this->plugin_textdomain ) )
-//		);
-
+		beans_add_smart_action( 'beans_footer', array( $this, 'beans_simple_edits_center_footer' ) );
 	}
 
-	/**
-	 *
-	 */
-	function beans_simple_edits_footer_content() {
 
-		beans_open_markup_e( 'beans_footer_credit_hit', 'div', array(
+	/**
+	 * Output the Beans Simple Edits Center Footer
+	 */
+	function beans_simple_edits_center_footer() {
+
+		beans_open_markup_e( 'beans_footer_credit', 'div', array(
 			'class' => 'uk-clearfix uk-text-small uk-text-muted uk-align-center'
 		) );
 
@@ -256,4 +224,73 @@ class Beans_Simple_Edits_Core {
 
 	}
 
+	/**
+	 * Output the Beans Simple Edits Split Footer
+	 */
+	function beans_simple_edits_split_footer() {
+
+		if ( $this->split_footer_left ) {
+
+			ob_start();
+			beans_output_e( 'beans_footer_credit_text', sprintf(
+				__( '&#x000A9; %1$s - %2$s. All rights reserved.', 'tm-beans' ),
+				date( 'Y' ),
+				get_bloginfo( 'name' )
+			) );
+			$beans_left_credit = ob_get_clean();
+
+		} else {
+
+			$beans_left_credit =  do_shortcode( __( $this->split_footer_left, $this->plugin_textdomain ) );
+		}
+
+
+		if ( $this->split_footer_right ) {
+
+			$beans_right_credit = beans_open_markup( 'beans_footer_credit_framework_link', 'a', array(
+				'href' => 'http://www.getbeans.io', // Automatically escaped.
+				'rel'  => 'designer',
+			) );
+
+			$beans_right_credit .= beans_output( 'beans_footer_credit_framework_link_text', 'Beans' );
+
+			$beans_right_credit .= beans_close_markup( 'beans_footer_credit_framework_link', 'a' );
+
+			$beans_right_credit .= beans_output( 'beans_footer_credit_framework_after_link_text', ' theme for WordPress' );
+
+		} else {
+
+			$beans_right_credit =  do_shortcode( __( $this->split_footer_right, $this->plugin_textdomain ) );
+		}
+
+
+		beans_open_markup_e( 'beans_footer_credit', 'div', array( 'class' => 'uk-clearfix uk-text-small uk-text-muted' ) );
+
+		beans_open_markup_e( 'beans_footer_credit_left', 'span', array(
+			'class' => 'uk-align-medium-left uk-margin-small-bottom',
+		) );
+
+		beans_output_e(
+			'beans_footer_credit_text',
+			$beans_left_credit
+		);
+
+		beans_close_markup_e( 'beans_footer_credit_left', 'span' );
+
+		beans_open_markup_e( 'beans_footer_credit_right', 'span', array(
+			'class' => 'uk-align-medium-right uk-margin-bottom-remove',
+		) );
+
+		beans_output_e(
+			'beans_footer_credit_text',
+			$beans_right_credit
+		);
+
+		beans_close_markup_e( 'beans_footer_credit_right', 'span' );
+
+		beans_close_markup_e( 'beans_footer_credit', 'div' );
+	}
+
 }
+
+

--- a/src/class-beans-simple-edits-core.php
+++ b/src/class-beans-simple-edits-core.php
@@ -71,7 +71,7 @@ class Beans_Simple_Edits_Core {
 		$this->remove_post_meta_below_content = get_option( 'beans_remove_post_meta_below_content_checkbox' );
 		$this->split_footer_left              = get_option( 'beans_split_footer_left' );
 		$this->remove_split_footer_left       = get_option( 'beans_remove_split_footer_left_checkbox' );
-		$this->split_footer_right             = get_option( 'beans_split_footer_left' );
+		$this->split_footer_right             = get_option( 'beans_split_footer_right' );
 		$this->remove_split_footer_right      = get_option( 'beans_remove_split_footer_right_checkbox' );
 		$this->center_footer                  = get_option( 'beans_center_footer' );
 		$this->show_center_footer             = get_option( 'beans_show_center_footer_checkbox' );
@@ -105,15 +105,20 @@ class Beans_Simple_Edits_Core {
 			}
 		}
 
-		add_filter( 'beans_footer_credit_text_output', array( $this, 'modify_footer_credit_text_left' ) );
 
-		add_filter( 'beans_footer_credit_right_text_output', array( $this, 'modify_footer_credit_text_right' ) );
 
 		if ( $this->show_center_footer ) {
 
 			beans_remove_action( 'beans_footer_content' );
 
-			add_action( 'beans_footer', array( $this, 'beans_simple_edits_footer_content' ), 25 );
+			beans_add_smart_action( 'beans_footer', array( $this, 'beans_simple_edits_footer_content' ) );
+
+		} else {
+
+			beans_add_filter( 'beans_footer_credit_text_output', array( $this, 'modify_footer_credit_text_left' ), 9999 );
+
+			beans_add_filter( 'beans_footer_credit_right_text_output', array( $this, 'modify_footer_credit_text_right' ), 9999 );
+
 		}
 
 	}
@@ -198,6 +203,11 @@ class Beans_Simple_Edits_Core {
 
 		return do_shortcode( __( $this->split_footer_right, $this->plugin_textdomain ) );
 
+//		return beans_output_e(
+//			'beans_footer_center_credit_text',
+//			do_shortcode( __( $this->split_footer_right, $this->plugin_textdomain ) )
+//		);
+
 	}
 
 	/**
@@ -205,7 +215,7 @@ class Beans_Simple_Edits_Core {
 	 */
 	function beans_simple_edits_footer_content() {
 
-		beans_open_markup_e( 'beans_footer_credit', 'div', array(
+		beans_open_markup_e( 'beans_footer_credit_hit', 'div', array(
 			'class' => 'uk-clearfix uk-text-small uk-text-muted uk-align-center'
 		) );
 
@@ -235,15 +245,14 @@ class Beans_Simple_Edits_Core {
 		} else {
 
 			beans_output_e(
-				'beans_footer_credit_right_text',
+				'beans_footer_center_credit_text',
 				do_shortcode( __( $this->center_footer, $this->plugin_textdomain ) )
 			);
-
 		}
 
 		beans_close_markup_e( 'beans_footer_credit_span', 'span' );
 
-		beans_close_markup_e( 'beans_footer_credit', 'div' );
+		beans_close_markup_e( 'beans_footer_credit_hit', 'div' );
 
 	}
 

--- a/src/class-beans-simple-edits.php
+++ b/src/class-beans-simple-edits.php
@@ -47,11 +47,9 @@ class Beans_Simple_Edits {
 	 */
 	function __construct() {
 
-		$edits_array = array( 'post_meta', 'split_footer', 'center_footer' );
-
 		$this->plugin_dir_url  = plugin_dir_url( __FILE__ );
 		$this->plugin_dir_path = plugin_dir_path( __FILE__ );
-		$this->simple_edits    = $edits_array;
+		$this->simple_edits    = array( 'post_meta', 'split_footer', 'center_footer' );
 
 	}
 

--- a/src/class-beans-simple-edits.php
+++ b/src/class-beans-simple-edits.php
@@ -40,10 +40,6 @@ class Beans_Simple_Edits {
 	 */
 	public $admin;
 
-	public $simple_shortcodes;
-
-	public $test;
-
 	/**
 	 * Constructor.
 	 *

--- a/src/class-beans-simple-edits.php
+++ b/src/class-beans-simple-edits.php
@@ -2,6 +2,7 @@
 
 namespace LearningCurve\BeansSimpleEdits;
 
+
 class Beans_Simple_Edits {
 
 	/**
@@ -39,6 +40,10 @@ class Beans_Simple_Edits {
 	 */
 	public $admin;
 
+	public $simple_shortcodes;
+
+	public $test;
+
 	/**
 	 * Constructor.
 	 *
@@ -46,9 +51,11 @@ class Beans_Simple_Edits {
 	 */
 	function __construct() {
 
+		$edits_array = array( 'post_meta', 'split_footer', 'center_footer' );
+
 		$this->plugin_dir_url  = plugin_dir_url( __FILE__ );
 		$this->plugin_dir_path = plugin_dir_path( __FILE__ );
-		$this->simple_edits    = array( 'post_meta', 'split_footer', 'center_footer' );
+		$this->simple_edits    = $edits_array;
 
 	}
 

--- a/src/views/admin.php
+++ b/src/views/admin.php
@@ -8,5 +8,16 @@
             ?>
 		</span>
 	</h2>
-	<?php echo beans_options( 'beans_simple_edits_settings' ); ?>
+    <?php
+if( ! class_exists( 'LearningCurve\BeansSimpleShortcodes\Beans_Simple_Shortcodes' ) ) {
+?>
+        <div class="notice notice-success is-dismissible">
+            <p>
+	            <?php _e( 'Beans Simple Edits works well with the <a href="https://github.com/JeffCleverley/BeansSimpleShortcodes" target="_blank">Beans Simple Shortcodes Plugin</a> to easily display post and site information in the Beans Simple Edits content areas!', $this->plugin_textdomain ); ?>
+            </p>
+        </div>
+    <?php
+    }
+?>
+	<div><?php echo beans_options( 'beans_simple_edits_settings' ); ?></div>
 </div>


### PR DESCRIPTION
Added integration with Beans Simple Shortcodes Plugin

- Checks if Beans Simple Shortcodes is active by class_exists()
-- If not, displays a dismissible notice with the link to the repo and suggestion
-- if so, it displays a metabox containing all the enabled shortcodes and link to settings page for documentation

Refactored the displaying of the Split and Center footer to resolve problems with third party themes who may have already manipulated and customised the footer

- Removes all footers after theme setup
- Adds new footer of type defined by Beans Simple Edits configuration

Also updated docblocks etc